### PR TITLE
Fix bug in font list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "BTT-Writer",
   "productName": "BTT-Writer",
-  "version": "1.0.2",
-  "build": "3",
+  "version": "1.0.3",
+  "build": "4",
   "description": "A utility for translating the Bible and biblical content into any language. (from tS 11.1.0)",
   "keywords": [],
   "homepage": "https://github.com/wycliffeassociates/ts-desktop",

--- a/src/js/lib/utils.js
+++ b/src/js/lib/utils.js
@@ -412,7 +412,7 @@ var utils = {
         }).map(function (fontobject) {
             var name = false;
             try {
-                name = fontobject.font.familyName;
+                name = fontobject.font.familyName.toString();
             } catch (e) {}
             if (name) {
                 return {path: fontobject.path, name: name};

--- a/win64_installer.iss
+++ b/win64_installer.iss
@@ -2,8 +2,8 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "BTT-Writer"
-#define Version "1.0.2"
-#define Build "3"
+#define Version "1.0.3"
+#define Build "4"
 #define MyAppPublisher "Wycliffe Associates"
 #define MyAppURL "https://writer.bibletranslationtools.org"
 #define MyAppExeName "BTT-Writer.exe"


### PR DESCRIPTION
Fix bug in Windows causing app to hang when loading a font list.  

Certain font names on Windows are returned as `Buffer[]` instead of `String`, causing the sort operation to fail when trying to compare them.  This string coerces them all to strings before sorting them.